### PR TITLE
Add method Cache#get_by_no_lock

### DIFF
--- a/src/localmemcache.c
+++ b/src/localmemcache.c
@@ -333,6 +333,12 @@ const char *__local_memcache_get(local_memcache_t *lmc, const char *key, size_t 
   return r;
 }
 
+const char *__local_memcache_get_by_no_lock(local_memcache_t *lmc, const char *key, size_t n_key, size_t *n_value)
+{
+  const char *r = ht_get(lmc->base, lmc->va_hash, key, n_key, n_value);
+  return r;
+}
+
 char *local_memcache_get_new(local_memcache_t *lmc, const char *key, size_t n_key, size_t *n_value)
 {
   const char *r = __local_memcache_get(lmc, key, n_key, n_value);

--- a/src/localmemcache.h
+++ b/src/localmemcache.h
@@ -222,6 +222,9 @@ int local_memcache_check_namespace(const char *namespace, const char *filename, 
 const char *__local_memcache_get(local_memcache_t *lmc, const char *key, size_t n_key, size_t *n_value);
 
 /* internal, do not use */
+const char *__local_memcache_get_by_no_lock(local_memcache_t *lmc, const char *key, size_t n_key, size_t *n_value);
+
+/* internal, do not use */
 int __local_memcache_random_pair(local_memcache_t *lmc, char **r_key, size_t *n_key, char **r_value, size_t *n_value);
 
 /* internal, do not use */

--- a/src/mruby_cache_gem.c
+++ b/src/mruby_cache_gem.c
@@ -263,6 +263,25 @@ static mrb_value Cache__get(mrb_state *mrb, mrb_value self)
 
 /*
  *  call-seq:
+ *     lmc.get_by_no_lock(key)   ->   string value or nil
+ *
+ *  Retrieve string value from hashtable without obtain a semaphore.
+ */
+static mrb_value Cache__get_by_no_lock(mrb_state *mrb, mrb_value self)
+{
+  local_memcache_t *lmc = get_Cache(mrb, self);
+  size_t l;
+  char *key;
+  mrb_int n_key;
+
+  mrb_get_args(mrb, "s", &key, &n_key);
+  const char *r = __local_memcache_get_by_no_lock(lmc, key, n_key, &l);
+  mrb_value rr = lmc_ruby_string2(mrb, r, l);
+  return rr;
+}
+
+/*
+ *  call-seq:
  *     lmc.set(key, value)   ->   Qnil
  *     lmc[key]=value        ->   Qnil
  *
@@ -462,6 +481,7 @@ void mrb_mruby_cache_gem_init(mrb_state *mrb)
 
   mrb_define_method(mrb, Cache, "get", Cache__get, MRB_ARGS_REQ(1));
   mrb_define_method(mrb, Cache, "[]", Cache__get, MRB_ARGS_REQ(1));
+  mrb_define_method(mrb, Cache, "get_by_no_lock", Cache__get_by_no_lock, MRB_ARGS_REQ(1));
   mrb_define_method(mrb, Cache, "delete", Cache__delete, MRB_ARGS_REQ(1));
   mrb_define_method(mrb, Cache, "set", Cache__set, MRB_ARGS_REQ(2));
   mrb_define_method(mrb, Cache, "clear", Cache__clear, MRB_ARGS_NONE());

--- a/test/cache.rb
+++ b/test/cache.rb
@@ -18,6 +18,10 @@ assert('get value') do
 	assert_equal $cache_x['test'], $cache_y['test']
 end
 
+assert('get_by_no_lock value') do
+	assert_equal $cache_x.get_by_no_lock('test'), $cache_y.get_by_no_lock('test')
+end
+
 assert('shm_status keys') do
 	status = $cache_x.shm_status
 	assert_equal status.keys.sort, [:free_bytes, :free_chunks, :largest_chunk, :total_bytes, :used_bytes]


### PR DESCRIPTION
Add method Cache#get_by_no_lock.
`Cache#get_by_no_lock` is without semaphore obtain from `Cache#get`.
The reason is because I want to emphasize speed rather than consistency.
`Cache#get_by_no_lock` is a read-only function, I think that there is no problem.

Please check.