### PR TITLE
Include only when the version is 3.2 or higher

### DIFF
--- a/src/mruby_cache_gem.c
+++ b/src/mruby_cache_gem.c
@@ -7,7 +7,7 @@
 #include "mruby/variable.h"
 #include "mruby/string.h"
 #include "mruby/array.h"
-#if MRUBY_RELEASE_MAJOR >= 3 && MRUBY_RELEASE_MINOR >= 2
+#if MRUBY_RELEASE_MAJOR > 3 || (MRUBY_RELEASE_MAJOR == 3 && MRUBY_RELEASE_MINOR >= 2)
 #include "mruby/internal.h"
 #endif
 #include <sys/types.h>

--- a/src/mruby_cache_gem.c
+++ b/src/mruby_cache_gem.c
@@ -7,7 +7,9 @@
 #include "mruby/variable.h"
 #include "mruby/string.h"
 #include "mruby/array.h"
+#if MRUBY_RELEASE_MAJOR >= 3 && MRUBY_RELEASE_MINOR >= 2
 #include "mruby/internal.h"
+#endif
 #include <sys/types.h>
 #include <unistd.h>
 #include "localmemcache.h"


### PR DESCRIPTION
Fix build errors when using less than mruby 3.2

fix: https://github.com/matsumotory/mruby-localmemcache/issues/8